### PR TITLE
Refactor ResolvedModule interface to extract common properties

### DIFF
--- a/tools-android/src/main/java/io/yamsergey/adt/tools/android/model/module/ResolvedModule.java
+++ b/tools-android/src/main/java/io/yamsergey/adt/tools/android/model/module/ResolvedModule.java
@@ -1,10 +1,19 @@
 package io.yamsergey.adt.tools.android.model.module;
 
 /**
- * TODO: each class that implements this interface has properties path and name,
- * hence they
- * can be moved under parent interface.
+ * Base interface for all resolved module types in an Android/Gradle project.
+ * All implementations must provide name and path information.
  **/
 public sealed interface ResolvedModule
     permits ResolvedAndroidModule, ResolvedGenericModule, UnknownModule, FailedModule {
+
+    /**
+     * @return the name of the module (e.g., "app", "core", "feature-auth")
+     */
+    String name();
+
+    /**
+     * @return the absolute filesystem path to the module directory
+     */
+    String path();
 }


### PR DESCRIPTION
## Summary
Extracts common `name` and `path` properties to the `ResolvedModule` parent interface, eliminating duplication across all implementations.

## Changes
- Added `name()` and `path()` methods to `ResolvedModule` interface
- All implementations (records) automatically satisfy these methods via their components
- No changes needed to implementing classes

## Benefits
- Reduced code duplication
- Cleaner, more consistent API
- Easier maintenance

## Testing
- ✅ Full project build passes
- ✅ CLI workspace output verified

Closes #9